### PR TITLE
Try to fix entrypoint

### DIFF
--- a/root/app/www/public/functions/docker.php
+++ b/root/app/www/public/functions/docker.php
@@ -479,7 +479,7 @@ function dockerAutoRun($container)
     if ($containerArray['Config']['Entrypoint']) {
         $entryPoints = [];
 
-        if(!empty($containerArray['Config']['Cmd'])) {
+        if (!empty($containerArray['Config']['Cmd'])) {
             foreach ($containerArray['Config']['Entrypoint'] as $entryPoint) {
                 $entryPoints[] = $entryPoint;
             }
@@ -492,13 +492,14 @@ function dockerAutoRun($container)
 
     $runCommand[] = $indent . '"' . $containerArray['Config']['Image'] . '" \\';
 
+    //-- COMMAND
     if (!empty($containerArray['Config']['Cmd'])) {
         $runCommand[] = $indent . '"' . implode('" "', $containerArray['Config']['Cmd']) . '" \\';
     } else {
         $containerCmd = $containerArray['Config']['Entrypoint'];
         array_shift($containerCmd);
 
-        if(count($containerCmd) >= 1) {
+        if (!empty($containerCmd)) {
             $runCommand[] = $indent . '"' . implode('" "', $containerCmd) . '" \\';
         }
     }

--- a/root/app/www/public/functions/docker.php
+++ b/root/app/www/public/functions/docker.php
@@ -478,8 +478,13 @@ function dockerAutoRun($container)
     //-- ENTRY
     if ($containerArray['Config']['Entrypoint']) {
         $entryPoints = [];
-        foreach ($containerArray['Config']['Entrypoint'] as $entryPoint) {
-            $entryPoints[] = $entryPoint;
+
+        if(!empty($containerArray['Config']['Cmd'])) {
+            foreach ($containerArray['Config']['Entrypoint'] as $entryPoint) {
+                $entryPoints[] = $entryPoint;
+            }
+        } else {
+            $entryPoints[] = $containerArray['Config']['Entrypoint'][0];
         }
 
         $runCommand[] = $indent . '--entrypoint "' .  implode('" "', $entryPoints) . '" \\';
@@ -489,6 +494,13 @@ function dockerAutoRun($container)
 
     if (!empty($containerArray['Config']['Cmd'])) {
         $runCommand[] = $indent . '"' . implode('" "', $containerArray['Config']['Cmd']) . '" \\';
+    } else {
+        $containerCmd = $containerArray['Config']['Entrypoint'];
+        array_shift($containerCmd);
+
+        if(count($containerCmd) >= 1) {
+            $runCommand[] = $indent . '"' . implode('" "', $containerCmd) . '" \\';
+        }
     }
 
     $runCommand = implode($glue, $runCommand);


### PR DESCRIPTION
Sometimes the entrypoint got confused, therefore some containers did not update successfully.

Example using Homarr:

Before:
```
--entrypoint "sh" "./scripts/run.sh" \
"ghcr.io/ajnart/homarr:latest" 
```

After:
```
--entrypoint "sh" \
"ghcr.io/ajnart/homarr:latest" \
"./scripts/run.sh"
```