### PR TITLE
"node-exporter" and "agent" aliases

### DIFF
--- a/root/app/www/public/container-alias.json
+++ b/root/app/www/public/container-alias.json
@@ -1,6 +1,6 @@
 {
     "apprise": ["apprise-api"],
     "grafana": ["grafana-image-renderer"],
-    "portainer": ["portainer-ce", "portainer-be", "portainer_agent", "portainer-ee"],
-    "prometheus": ["node_exporter"]
+    "portainer": ["portainer-ce", "portainer-be", "portainer_agent", "agent", "portainer-ee"],
+    "prometheus": ["node-exporter"]
 }


### PR DESCRIPTION
Corrected "node-exporter" for Prometheus alias and added "agent" for Portainer alias