### PR TITLE
Update run to fix lsiown syntax issue

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-dockwatch-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-dockwatch-config/run
@@ -6,4 +6,4 @@ s6-setuidgid abc php -r "require '/app/www/public/startup.php';"
 echo 's6-overlay init require(/app/www/public/startup.php) <-';
 
 # permissions
-lsiown -R abc:abc /config
+find /config ! -user abc -exec chown abc {} +

--- a/root/etc/s6-overlay/s6-rc.d/init-dockwatch-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-dockwatch-config/run
@@ -6,4 +6,4 @@ s6-setuidgid abc php -r "require '/app/www/public/startup.php';"
 echo 's6-overlay init require(/app/www/public/startup.php) <-';
 
 # permissions
-lsiown -R abc /config
+lsiown -R abc:abc /config


### PR DESCRIPTION
@austinwbest, I noticed an issue with the lsiown syntax in the s6 run command that was preventing the container from chowning its files, and this PR should resolve it.  😄 