### PR TITLE
fix: use correct key name for container status in health cron

### DIFF
--- a/root/app/www/public/crons/health.php
+++ b/root/app/www/public/crons/health.php
@@ -34,7 +34,7 @@ logger(CRON_HEALTH_LOG, '$unhealthy=' . json_encode($unhealthy, JSON_UNESCAPED_S
 foreach ($containerList as $container) {
     $nameHash = md5($container['name']);
 
-    if (!str_contains($container['State'], 'running')) {
+    if (!str_contains($container['status'], 'running')) {
         unset($unhealthy[$nameHash]);
         logger(CRON_HEALTH_LOG, 'container \'' . $container['name'] . '\' is not running and wont be checked');
         continue;


### PR DESCRIPTION
## Summary

- Fix `$container['State']` → `$container['status']` in `health.php` line 37
- The `stats/containers` API returns the field as lowercase `status`, but health.php referenced `State` (capital S)
- This caused `str_contains(null, 'running')` → `false` for every container, skipping all health checks and making `restartUnhealthy` non-functional

## Details

`getContainerStats()` in `stats.php` reads `$container['State']` from `state.json` but outputs it as `'status' => $status` in the returned array. The health cron still referenced the original key name `State`, which doesn't exist in the API response.

Introduced in [`785d72b4`](https://github.com/Notifiarr/dockwatch/commit/785d72b4) (2025-08-23).

## Test Plan

- [x] Verified fix locally by patching running container and triggering health cron
- [x] Before: all 141 containers skipped as "not running", `$unhealthy=[]`
- [x] After: containers correctly categorized as healthy/unhealthy/no-healthcheck/stopped
- [x] `restartUnhealthy` logic now reachable

Fixes #108