### PR TITLE
fix(security): escapeshellarg compose paths + exit after auth redirect (CVE-2026-58455)

### DIFF
--- a/root/app/www/public/ajax/compose.php
+++ b/root/app/www/public/ajax/compose.php
@@ -246,12 +246,12 @@ if ($_POST['m'] == 'composeAdd') {
 
 if ($_POST['m'] == 'composeDelete') {
     if (substr($_POST['composePath'], 0, strlen(COMPOSE_PATH)) == COMPOSE_PATH) {
-        $shell->exec('rm -rf ' . $_POST['composePath']);
+        $shell->exec('rm -rf ' . escapeshellarg($_POST['composePath']));
     }
 }
 
 if ($_POST['m'] == 'composePull') {
-    $cmd  = sprintf(DockerSock::COMPOSE_PULL, $_POST['composePath']);
+    $cmd  = sprintf(DockerSock::COMPOSE_PULL, escapeshellarg($_POST['composePath']));
     $pull = $shell->exec($cmd . ' 2>&1');
 
     if (str_contains_all($pull, ['Pulling', 'Pulled'])) {
@@ -262,7 +262,7 @@ if ($_POST['m'] == 'composePull') {
 }
 
 if ($_POST['m'] == 'composeUp') {
-    $cmd = sprintf(DockerSock::COMPOSE_UP, $_POST['composePath']);
+    $cmd = sprintf(DockerSock::COMPOSE_UP, escapeshellarg($_POST['composePath']));
     $up  = $shell->exec($cmd . ' 2>&1');
 
     if (str_contains_all($up, ['Container', 'Started']) || str_contains_all($up, ['Container', 'Running'])) {
@@ -273,7 +273,7 @@ if ($_POST['m'] == 'composeUp') {
 }
 
 if ($_POST['m'] == 'composeStop') {
-    $cmd  = sprintf(DockerSock::COMPOSE_STOP, $_POST['composePath']);
+    $cmd  = sprintf(DockerSock::COMPOSE_STOP, escapeshellarg($_POST['composePath']));
     $stop = $shell->exec($cmd . ' 2>&1');
 
     if (str_contains($stop, 'Stopped') || str_contains($stop, 'done')) {
@@ -284,7 +284,7 @@ if ($_POST['m'] == 'composeStop') {
 }
 
 if ($_POST['m'] == 'composeDown') {
-    $cmd  = sprintf(DockerSock::COMPOSE_DOWN, $_POST['composePath']);
+    $cmd  = sprintf(DockerSock::COMPOSE_DOWN, escapeshellarg($_POST['composePath']));
     $down = $shell->exec($cmd . ' 2>&1');
 
     if (str_contains_all($down, ['Container', 'Stopped'])) {
@@ -295,7 +295,7 @@ if ($_POST['m'] == 'composeDown') {
 }
 
 if ($_POST['m'] == 'composeRestart') {
-    $cmd     = sprintf(DockerSock::COMPOSE_RESTART, $_POST['composePath']);
+    $cmd     = sprintf(DockerSock::COMPOSE_RESTART, escapeshellarg($_POST['composePath']));
     $restart = $shell->exec($cmd . ' 2>&1');
 
     if (str_contains($restart, 'Started') || str_contains($restart, 'Restart')) {
@@ -306,7 +306,7 @@ if ($_POST['m'] == 'composeRestart') {
 }
 
 if ($_POST['m'] == 'composePs') {
-    $cmd    = sprintf(DockerSock::COMPOSE_PS, $_POST['composePath'], '-a');
+    $cmd    = sprintf(DockerSock::COMPOSE_PS, escapeshellarg($_POST['composePath']), '-a');
     $output = $shell->exec($cmd . ' 2>&1');
 
     if (str_contains($output, 'Error') || str_contains($output, 'error')) {
@@ -368,6 +368,6 @@ if ($_POST['m'] == 'composePs') {
 }
 
 if ($_POST['m'] == 'composeLogs') {
-    $cmd = sprintf(DockerSock::COMPOSE_LOGS, $_POST['composePath']);
+    $cmd = sprintf(DockerSock::COMPOSE_LOGS, escapeshellarg($_POST['composePath']));
     echo $shell->exec($cmd . ' 2>&1');
 }

--- a/root/app/www/public/loader.php
+++ b/root/app/www/public/loader.php
@@ -249,6 +249,7 @@ if (!str_contains_any($_SERVER['PHP_SELF'], ['/api/']) && !str_contains($_SERVER
     if (!$_SESSION['authenticated']) {
         if (!str_contains($_SERVER['PHP_SELF'], 'login.php')) {
             header('Location: login.php');
+            exit;
         }
     } else {
         logger(SYSTEM_LOG, 'Starting');


### PR DESCRIPTION
## Summary

Fixes an unauthenticated OS command execution issue in the compose management
endpoint. Reported via VulnCheck coordinated disclosure — **CVE-2026-58455**.

Two root causes, both addressed here:

1. **Execution After Redirect (loader.php).** When an unauthenticated request
   hits an auth-gated page, `loader.php` sends `header('Location: login.php')`
   but does not `exit()`, so execution continues past the auth check. This PR
   adds the missing `exit;`.

2. **Unsanitized composePath (ajax/compose.php).** The compose actions
   (`composePull/Up/Stop/Down/Restart/Ps/Logs`, and `composeDelete`'s `rm -rf`)
   interpolate `$_POST['composePath']` directly into shell commands via
   `sprintf(... 'cd %s && docker compose ...')` → `Shell::exec()`
   (`shell_exec`). A path containing shell metacharacters (e.g. `x;id;#`)
   executes arbitrary commands. This PR wraps the path in `escapeshellarg()`,
   matching the pattern `composeSave` already uses.

Note: the existing `substr(...) == COMPOSE_PATH` prefix check on
`composeSave`/`composeDelete` scopes the *path* but does not neutralize shell
metacharacters (a value like `/config/compose/;id` still starts with
`COMPOSE_PATH`), so `escapeshellarg()` is the actual fix.

## Changes
- `loader.php`: add `exit;` after the login redirect.
- `ajax/compose.php`: `escapeshellarg()` on `composePath` in all shell sinks
  (7 `sprintf` compose actions + `composeDelete`'s `rm -rf`).

## Testing
- Compose actions still function with legitimate paths (quoted argument to `cd`
  behaves identically for valid paths).
- The injection payload no longer executes after the change.