### PR TITLE
chore(github): normalize issue type case to match org types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,7 +2,7 @@ name: Bug Report
 description: File a bug report to help us improve Dockwatch
 title: "Bug - "
 labels: ["bug", "triage"]
-type: bug
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: Feature Request
 description: Suggest an idea or enhancement for Dockwatch
 title: "FR - "
 labels: ["enhancement", "triage"]
-type: feature
+type: Feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
The issue forms set `type: bug` / `type: feature` (lowercase), but the Notifiarr org-level issue types are named **Bug** / **Feature**. This capitalizes the `type:` values so they match the defined org issue types exactly.

No other changes.